### PR TITLE
Made annotations enabled by default, changed PDF to include annotations when checked

### DIFF
--- a/templates/unit_template.html
+++ b/templates/unit_template.html
@@ -1,78 +1,61 @@
 <!DOCTYPE html>
 <html lang="en">
+  $unitHead
 
-$unitHead
+  <body>
+    <!-- Navigation -->
+    $unitSidebar $unitSecondarySidebar $unitMobileSidebar
 
-<body>
-		
-		  <!-- Navigation -->
-			$unitSidebar
-			$unitSecondarySidebar
-			$unitMobileSidebar
-		
-		
-	<div class="content secondary">
-		<!-- Overview -->
-		<div class="row">
-			<div class="col-lg-12 text-left">
-				<h1 tabindex = "1">$heading</h1>
-				$Information
-			</div>
-		</div>
-
-        <!-- Notes -->
-		<div class="daily">
-		</div>
-
-		
-				
-		<!---Non-annotated notes will be the default-->
-		<p>
-			
-		</p>
-
-		<div id="PDF">
-            $PDF
+    <div class="content secondary">
+      <!-- Overview -->
+      <div class="row">
+        <div class="col-lg-12 text-left">
+          <h1 tabindex="1">$heading</h1>
+          $Information
         </div>
-        <script>
-			
-			const toggles = document.querySelector('.toggle input');
-			
-			toggles.addEventListener('click', () => {
-    		const onOff = toggles.parentNode.querySelector('.onoff')
-    		onOff.textContent = toggles.checked ? 'ON' : 'OFF'
-			})
-			
-			// const divs = document.querySelectorAll('.toggle input');
+      </div>
 
-			// divs.forEach(el => el.addEventListener('click', () => {
-    		// const onOff = el.parentNode.querySelector('.onoff')
-    		// onOff.textContent = el.checked ? 'ON' : 'OFF'
-			// }));
-			
-			function annotations(num, notes, annotated,id) {
-				var doc;
-				var drive;
-				if (document.getElementById('toggle-'+num).checked) {
-					doc = "web/viewer.html?file=../" +annotated
-					
-				} 
+      <!-- Notes -->
+      <div class="daily"></div>
 
-				else {
-					doc = "web/viewer.html?file=../"+notes
-				}
-				
-                document.getElementById(id).src = doc;
-			}
-		</script>
-        <br><br>	
-		
-       <div id="embeddedLinks">
-		   $embed
-	   </div>
-			
-	</div>
-	
-</body>
+      <!---Non-annotated notes will be the default-->
+      <p></p>
 
+      <div id="PDF">$PDF</div>
+      <script>
+        const toggles = document.querySelector(".toggle input");
+
+        toggles.addEventListener("click", () => {
+          const onOff = toggles.parentNode.querySelector(".onoff");
+          onOff.textContent = toggles.checked ? "ON" : "OFF";
+        });
+
+        // const divs = document.querySelectorAll('.toggle input');
+
+        // divs.forEach(el => el.addEventListener('click', () => {
+        // const onOff = el.parentNode.querySelector('.onoff')
+        // onOff.textContent = el.checked ? 'ON' : 'OFF'
+        // }));
+
+        function annotations(num, notes, annotated, id) {
+          var doc;
+          var drive;
+          var downloadFile;
+          if (document.getElementById("toggle-" + num).checked) {
+            doc = "web/viewer.html?file=../" + annotated;
+            downloadFile = annotated;
+          } else {
+            doc = "web/viewer.html?file=../" + notes;
+            downloadFile = notes;
+          }
+
+          document.getElementById(id + "-download").href = downloadFile;
+          document.getElementById(id).src = doc;
+        }
+      </script>
+      <br /><br />
+
+      <div id="embeddedLinks">$embed</div>
+    </div>
+  </body>
 </html>

--- a/unit_template.py
+++ b/unit_template.py
@@ -91,12 +91,12 @@ for i in range(0,len(unitData)):
 
                 initialFileName = annotatedFileName if exists("files/" + annotatedFileName) else pdf
 
+                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
+                
                 #heading and PDF download button, only PDF download button in this case 
                 pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
                 <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ initialFileName + """ download>PDF</a> """
 
-                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
-                
                 if(exists("files/"+annotatedFileName)):
                     pdfString += """<div style="font-weight: 700; font-size: 120%; display: inline-block;">&nbsp&nbspAnnotations:&nbsp</div><label class="toggle">
                                 <span class="onoff">OFF</span>

--- a/unit_template.py
+++ b/unit_template.py
@@ -38,9 +38,19 @@ for i in range(0,len(unitData)):
                 if(tex == None):
                     tex=""
 
+                #id of pdf.js element formatting
+                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
+
+                #annotatedFileName will be as such: for Week4.tex -> Week4-annotated.pdf
+                annotatedFileName= unitData[i]['content'][j]['source'].replace(".tex","")
+                annotatedFileName = annotatedFileName+websiteData["Annotated"]+".pdf"
+
+                initialFileName = annotatedFileName if exists("files/" + annotatedFileName) else pdf
+
                 #heading and PDF download button, only PDF download button in this case 
                 pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
-                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ annotatedFileName+ """ download>PDF</a> """
+                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href=""" + initialFileName + """ download>PDF</a> """
+
                 #.tex
                 pdfString += """ <a tabindex = "2" class="button LaTeX" aria-label="Download .LaTeX" 
                     href=""" + tex + """ download>LaTeX</a> """
@@ -51,12 +61,6 @@ for i in range(0,len(unitData)):
                 
                
 
-                #id of pdf.js element formatting
-                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
-
-                #annotatedFileName will be as such: for Week4.tex -> Week4-annotated.pdf
-                annotatedFileName= unitData[i]['content'][j]['source'].replace(".tex","")
-                annotatedFileName = annotatedFileName+websiteData["Annotated"]+".pdf"
 
                 if(exists("files/"+annotatedFileName)):
                     #annotations switch/toggle
@@ -72,28 +76,31 @@ for i in range(0,len(unitData)):
                      """+str(elementCount)+""", \""""+pdf+ """\",\"../files/"""+annotatedFileName+"""\", \""""+pdfjsID+ """\")}; </script>"""
                 
                 #pdf.js embed default 
-                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../"""+ annotatedFileName+ """" 
+                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../"""+ initialFileName+ """" 
                 title="webviewer" frameborder="0" width="100%" height="600"></iframe> """
+
             
             #if source value ends with .pdf, refer to the files directory  
             elif (unitData[i]['content'][j]['source'][-4:] == '.pdf'):
                 pdf="../files/"+unitData[i]['content'][j]['source']
-
-                #heading and PDF download button, only PDF download button in this case 
-                pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
-                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ annotatedFileName+ """ download>PDF</a> """
-
-                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
                 
             
                 #annotatedFileName will be as such: for Week4.tex -> Week4-annotated.pdf
                 annotatedFileName= unitData[i]['content'][j]['source'].replace(".pdf","")
                 annotatedFileName = annotatedFileName+websiteData["Annotated"]+".pdf"
+
+                initialFileName = annotatedFileName if exists("files/" + annotatedFileName) else pdf
+
+                #heading and PDF download button, only PDF download button in this case 
+                pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
+                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ initialFileName + """ download>PDF</a> """
+
+                pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
                 
                 if(exists("files/"+annotatedFileName)):
                     pdfString += """<div style="font-weight: 700; font-size: 120%; display: inline-block;">&nbsp&nbspAnnotations:&nbsp</div><label class="toggle">
                                 <span class="onoff">OFF</span>
-                                            <input type="checkbox" />
+                                            <input type="checkbox" checked />
                         <span class="slider round" id="annotationsOnButton"""+str(elementCount)+""""></span>
                         </label> <br>"""
                     
@@ -103,7 +110,7 @@ for i in range(0,len(unitData)):
                      \""""+pdf+ """\",\"../files/"""+annotatedFileName+"""\", \""""+pdfjsID+ """\")}; </script>"""
 
                 #pdf.js embed from files
-                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../../files/"""+ annotatedFileName+ """" 
+                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../../files/"""+ initialFileName + """" 
                     title="webviewer" frameborder="0" width="100%" height="600"></iframe> """
             
             

--- a/unit_template.py
+++ b/unit_template.py
@@ -62,7 +62,7 @@ for i in range(0,len(unitData)):
                     #annotations switch/toggle
                     pdfString += """
                     <label class="switch">
-                    <input type="checkbox" id="toggle-"""+str(elementCount)+"""">
+                    <input type="checkbox" id="toggle-"""+str(elementCount)+"""" checked>
                     <span class="slider round"></span>
                     </label>
                     """

--- a/unit_template.py
+++ b/unit_template.py
@@ -40,7 +40,7 @@ for i in range(0,len(unitData)):
 
                 #heading and PDF download button, only PDF download button in this case 
                 pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
-                <a tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ pdf+ """ download>PDF</a> """
+                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ annotatedFileName+ """ download>PDF</a> """
                 #.tex
                 pdfString += """ <a tabindex = "2" class="button LaTeX" aria-label="Download .LaTeX" 
                     href=""" + tex + """ download>LaTeX</a> """
@@ -72,7 +72,7 @@ for i in range(0,len(unitData)):
                      """+str(elementCount)+""", \""""+pdf+ """\",\"../files/"""+annotatedFileName+"""\", \""""+pdfjsID+ """\")}; </script>"""
                 
                 #pdf.js embed default 
-                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../"""+ pdf+ """" 
+                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../"""+ annotatedFileName+ """" 
                 title="webviewer" frameborder="0" width="100%" height="600"></iframe> """
             
             #if source value ends with .pdf, refer to the files directory  
@@ -81,7 +81,7 @@ for i in range(0,len(unitData)):
 
                 #heading and PDF download button, only PDF download button in this case 
                 pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
-                <a tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ pdf+ """ download>PDF</a> """
+                <a id=\"""" + pdfjsID + """-download\" tabindex = "2" class="button PDF" aria-label="Download PDF" href="""+ annotatedFileName+ """ download>PDF</a> """
 
                 pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
                 
@@ -103,7 +103,7 @@ for i in range(0,len(unitData)):
                      \""""+pdf+ """\",\"../files/"""+annotatedFileName+"""\", \""""+pdfjsID+ """\")}; </script>"""
 
                 #pdf.js embed from files
-                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../../files/"""+ pdf+ """" 
+                pdfString += """ <br> <iframe class="PDFjs" id=\""""+ pdfjsID +"""\" src="web/viewer.html?file=../../files/"""+ annotatedFileName+ """" 
                     title="webviewer" frameborder="0" width="100%" height="600"></iframe> """
             
             

--- a/unit_template.py
+++ b/unit_template.py
@@ -45,7 +45,7 @@ for i in range(0,len(unitData)):
                 annotatedFileName= unitData[i]['content'][j]['source'].replace(".tex","")
                 annotatedFileName = annotatedFileName+websiteData["Annotated"]+".pdf"
 
-                initialFileName = annotatedFileName if exists("files/" + annotatedFileName) else pdf
+                initialFileName = ("../files/" + annotatedFileName) if exists("files/" + annotatedFileName) else pdf
 
                 #heading and PDF download button, only PDF download button in this case 
                 pdfString += """<h2 tabindex = "2"> """+ unitData[i]['content'][j]['name'] +"""</h2>
@@ -89,7 +89,7 @@ for i in range(0,len(unitData)):
                 annotatedFileName= unitData[i]['content'][j]['source'].replace(".pdf","")
                 annotatedFileName = annotatedFileName+websiteData["Annotated"]+".pdf"
 
-                initialFileName = annotatedFileName if exists("files/" + annotatedFileName) else pdf
+                initialFileName = ("../files/" + annotatedFileName) if exists("files/" + annotatedFileName) else pdf
 
                 pdfjsID = unitData[i]['content'][j]['source'].replace(" ", "-")
                 


### PR DESCRIPTION
Changed notes annotations to be enabled by default. Students will now click to disable annotations instead of clicking to enable.

Also, changed the PDF button to download notes with annotations when annotations are enabled. This obviously means that the PDF button will download annotations by default, since annotations are now enabled by default.

Tested on my own computer using the 'published' branch created by Github Actions to ensure everything worked correctly. Also made sure that PDFs that don't have annotations work as intended.